### PR TITLE
Added 'feh' as depend

### DIFF
--- a/pkg/AUR/PKGBUILD
+++ b/pkg/AUR/PKGBUILD
@@ -6,6 +6,7 @@ pkgrel=0
 pkgdesc="ShareX for Unix-like systems"
 url="https://github.com/ShareXin/ShareXin"
 makedepends=('rust' 'cargo' 'curl' 'gtk3' 'gdk-pixbuf2' 'cairo' 'glib2' 'openssl' 'dbus' 'xcb-util' 'gcc' 'cmake')
+depends=('feh')
 arch=('x86_64')
 license=('MIT')
 source=("$pkgname-$pkgver.tar.gz::https://crates.io/api/v1/crates/$pkgname/$pkgver/download")


### PR DESCRIPTION
feh is required at runtime for choosing an area of the screen, so I've added it as a depend in the PKGBUILD (I've also moved the PKGBUILD to a subdirectory, so the metadata makepkg generates doesn't clog the repo proper)